### PR TITLE
Rebuild with proj 8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,1 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - cmake.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgeotiff
@@ -27,9 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - proj 6.2.1  # [not ((osx and arm64) or (linux and s390x))]
-    - proj 7.2.0  # [osx and arm64]
-    - proj 8.2.1  # [linux and s390x]
+    - proj
     - zlib 1.2.*
     - jpeg 9e
     - libtiff 4.1  # [not ((osx and arm64) or (linux and aarch64))]


### PR DESCRIPTION
- Rebuild with proj 8.2.1
- Bumped build number
- Removed proj pinnings
- Changed abs.yaml to point to aggregate branch with proj pinned to 8.2.1