### PR TITLE
geotiff 1.7.0: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+export LIBRARY_PATH="$LIBRARY_PATH:$SDKROOT/usr/lib"
+
 cmake -D CMAKE_PREFIX_PATH=$PREFIX \
       -D CMAKE_INSTALL_PREFIX=$PREFIX \
-      -D WITH_PROJ4=ON \
       -D WITH_ZLIB=ON \
       -D BUILD_SHARED_LIBS=ON \
       -D WITH_JPEG=ON \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-export LIBRARY_PATH="$LIBRARY_PATH:$SDKROOT/usr/lib"
-
 cmake -D CMAKE_PREFIX_PATH=$PREFIX \
       -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D WITH_ZLIB=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - cmake.patch
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgeotiff
@@ -27,11 +27,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - proj 9.3.1
-    - zlib 1.2.*
-    - jpeg 9e
-    - libtiff 4.1  # [not ((osx and arm64) or (linux and aarch64))]
-    - libtiff 4.2  # [(osx and arm64) or (linux and aarch64)]
+    - proj {{ proj }}
+    - zlib {{ zlib }}
+    - jpeg {{ jpeg }}
+    - libtiff 4.7.0
   run:
     - proj
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - proj {{ proj }}
     - zlib {{ zlib }}
     - jpeg {{ jpeg }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
   run:
     - proj
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 4
-  skip: True  # [s390x or (win and vc<14)]
+  skip: True  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgeotiff
     - {{ pin_subpackage('geotiff', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,9 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libgeotiff${SHLIB_EXT}  # [not win]
+    - test -f $PREFIX/lib/libgeotiff${SHLIB_EXT}        # [not win]
     - if not exist %LIBRARY_LIB%\\geotiff_i.lib exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\\geotiff.dll exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\\geotiff.dll exit 1    # [win]
 
 about:
   home: https://trac.osgeo.org/geotiff

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 4
-  skip: True  # [win and vc<14]
+  skip: True  # [s390x or (win and vc<14)]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgeotiff
     - {{ pin_subpackage('geotiff', max_pin='x.x') }}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7586](https://anaconda.atlassian.net/browse/PKG-7586) 
- [Upstream repository](https://github.com/OSGeo/libgeotiff/tree/1.7.0)

### Explanation of changes:

- Bump the build number to 4
- Remove the obsolete flag WITH_PROJ4

### Notes:

-

[PKG-7586]: https://anaconda.atlassian.net/browse/PKG-7586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ