### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/libtiff-feedstock/pr26/8b5dc91

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/libtiff-feedstock/pr26/8b5dc91

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - cmake.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgeotiff
@@ -29,12 +29,12 @@ requirements:
   host:
     - proj {{ proj }}
     - libzlib {{ libzlib }}
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libtiff {{ libtiff }}
   run:
     - proj
     - libzlib
-    - jpeg
+    - libjpeg-turbo
     - libtiff
 
 test:


### PR DESCRIPTION
geotiff 1.7.4

**Destination channel:** defaults

### Links

- [PKG-13224](https://anaconda.atlassian.net/browse/PKG-13224) 
- [Upstream repository](https://github.com/OSGeo/libgeotiff/tree/1.7.4)

### Explanation of changes:
- Rebuild against libjpeg-turbo

[PKG-13224]: https://anaconda.atlassian.net/browse/PKG-13224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ